### PR TITLE
Prevent annotations from being applied to static fields

### DIFF
--- a/jfixture/src/main/java/com/flextrade/jfixture/FixtureAnnotations.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/FixtureAnnotations.java
@@ -32,7 +32,7 @@ public final class FixtureAnnotations {
     }
 
     private static boolean isWritable(Field field) {
-        return !Modifier.isFinal(field.getModifiers());
+        return !Modifier.isFinal(field.getModifiers()) && !Modifier.isStatic(field.getModifiers());
     }
 
     private static boolean isAnnotated(Field field) {


### PR DESCRIPTION
Modify the 'isWriteable' function to exclude static fields as well as final fields.
