### PR TITLE
Issue #24: Call @Before methods when using JFixtureJUnitRunner

### DIFF
--- a/jfixture-mockito/src/test/java/com/flextrade/jfixture/mockito/customisation/TestMockitoAutoPropertySpecification.java
+++ b/jfixture-mockito/src/test/java/com/flextrade/jfixture/mockito/customisation/TestMockitoAutoPropertySpecification.java
@@ -4,7 +4,6 @@ import com.flextrade.jfixture.utility.SpecimenType;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.flextrade.jfixture.mockito.customisation.MockitoAutoPropertySpecification;
 import com.flextrade.jfixture.mockito.testtypes.MockitoClass;
 
 import java.util.List;

--- a/jfixture/src/main/java/com/flextrade/jfixture/runners/JFixtureJUnitRunner.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/runners/JFixtureJUnitRunner.java
@@ -1,9 +1,6 @@
 package com.flextrade.jfixture.runners;
 
-import com.flextrade.jfixture.FixtureAnnotations;
 import com.flextrade.jfixture.JFixture;
-import com.flextrade.jfixture.behaviours.tracing.MemberOnlyResponseStrategy;
-import com.flextrade.jfixture.behaviours.tracing.TracingBehaviour;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;

--- a/jfixture/src/main/java/com/flextrade/jfixture/runners/JFixtureJUnitRunner.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/runners/JFixtureJUnitRunner.java
@@ -1,6 +1,9 @@
 package com.flextrade.jfixture.runners;
 
+import com.flextrade.jfixture.FixtureAnnotations;
 import com.flextrade.jfixture.JFixture;
+import com.flextrade.jfixture.behaviours.tracing.MemberOnlyResponseStrategy;
+import com.flextrade.jfixture.behaviours.tracing.TracingBehaviour;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunNotifier;
@@ -15,7 +18,8 @@ public class JFixtureJUnitRunner extends Runner {
     public JFixtureJUnitRunner(Class<?> clazz) throws InitializationError {
         this.runner = new BlockJUnit4ClassRunner(clazz) {
             protected Statement withBefores(FrameworkMethod method, Object target, Statement statement) {
-                return new JUnitJFixtureStatement(statement, target, new JFixture());
+                Statement base = super.withBefores(method, target, statement);
+                return new JUnitJFixtureStatement(base, target, new JFixture());
             }
         };
     }

--- a/jfixture/src/test/java/com/flextrade/jfixture/builders/TestDateGenerator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/builders/TestDateGenerator.java
@@ -2,7 +2,6 @@ package com.flextrade.jfixture.builders;
 
 import com.flextrade.jfixture.NoSpecimen;
 import com.flextrade.jfixture.utility.TimeProvider;
-import org.hamcrest.number.OrderingComparison;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;

--- a/jfixture/src/test/java/com/flextrade/jfixture/builders/TestNumericRangeRelay.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/builders/TestNumericRangeRelay.java
@@ -3,7 +3,6 @@ package com.flextrade.jfixture.builders;
 import com.flextrade.jfixture.NoSpecimen;
 import com.flextrade.jfixture.SpecimenContext;
 import com.flextrade.jfixture.exceptions.InvalidRequestException;
-import com.flextrade.jfixture.exceptions.ObjectCreationException;
 import com.flextrade.jfixture.requests.RangeRequest;
 import com.flextrade.jfixture.utility.SpecimenType;
 import org.junit.Before;

--- a/jfixture/src/test/java/component/extensions/TestCreateInRange.java
+++ b/jfixture/src/test/java/component/extensions/TestCreateInRange.java
@@ -2,7 +2,6 @@ package component.extensions;
 
 import com.flextrade.jfixture.JFixture;
 import com.flextrade.jfixture.exceptions.InvalidRequestException;
-import com.flextrade.jfixture.exceptions.ObjectCreationException;
 import org.junit.Test;
 
 import java.text.ParseException;

--- a/jfixture/src/test/java/component/runners/TestJFixtureJUnitRunner.java
+++ b/jfixture/src/test/java/component/runners/TestJFixtureJUnitRunner.java
@@ -2,6 +2,7 @@ package component.runners;
 
 import com.flextrade.jfixture.annotations.Fixture;
 import com.flextrade.jfixture.runners.JFixtureJUnitRunner;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -11,9 +12,20 @@ import static org.junit.Assert.assertNotNull;
 public class TestJFixtureJUnitRunner {
 
     @Fixture String value;
+    private Object testSubject;
+
+    @Before
+    public void setUp() throws Exception {
+        testSubject = new Object();
+    }
 
     @Test
     public void runner_instantiates_fields_marked_with_fixture_annotation() {
         assertNotNull(value);
+    }
+
+    @Test 
+    public void runner_calls_setup_method_before_running_tests() {
+        assertNotNull(testSubject);
     }
 }


### PR DESCRIPTION
When overriding BlockJUnit4ClassRunner.withBefores, you need to call super.withBefores. This gives us a new base statement to pass into JUnitJFixtureStatement.