### PR TITLE
Always pop monitored requests stack in RecursionGuard, even if request throws an exception

### DIFF
--- a/jfixture/src/main/java/com/flextrade/jfixture/behaviours/recursion/RecursionGuard.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/behaviours/recursion/RecursionGuard.java
@@ -29,10 +29,12 @@ class RecursionGuard implements SpecimenBuilder {
         }
 
         this.monitoredRequests.push(request);
-        Object specimen = this.builder.create(request, context);
-        this.monitoredRequests.pop();
-
-        return specimen;
+        try {
+            return this.builder.create(request, context);
+        }
+        finally {
+            this.monitoredRequests.pop();
+        }
     }
 
     public SpecimenBuilder builder() {

--- a/jfixture/src/test/java/component/TestFixture.java
+++ b/jfixture/src/test/java/component/TestFixture.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import testtypes.TypeWithBooleanConvention;
 import testtypes.TypeWithCircularReference;
 import testtypes.TypeWithFields;
+import testtypes.TypeWithFieldWithThrowingConstructor;
 import testtypes.TypeWithProperties;
 import testtypes.constructors.TypeWithConstructor;
 
@@ -55,5 +56,16 @@ public class TestFixture {
     public void applies_throwing_recursion_behaviour_by_default() {
         JFixture fixture = new JFixture();
         fixture.create(TypeWithCircularReference.class);
+    }
+    
+    @Test
+    public void array_of_type_containing_object_with_throwing_constructor_sets_fields_with_working_constructor() {
+        JFixture fixture = new JFixture();
+        TypeWithFieldWithThrowingConstructor[] types = fixture.create(TypeWithFieldWithThrowingConstructor[].class);
+
+        assertNotNull(types);
+        assertTrue(types.length > 0);
+        assertNotNull(types[0]);
+        assertNotNull(types[0].fieldWithThrowingConstructor);
     }
 }

--- a/jfixture/src/test/java/testtypes/TypeWithFieldWithThrowingConstructor.java
+++ b/jfixture/src/test/java/testtypes/TypeWithFieldWithThrowingConstructor.java
@@ -1,0 +1,7 @@
+package testtypes;
+
+import testtypes.constructors.TypeWithThrowingConstructor;
+
+public class TypeWithFieldWithThrowingConstructor {
+    public TypeWithThrowingConstructor fieldWithThrowingConstructor;
+}


### PR DESCRIPTION
We're trying to fixture an array of `TypeA`, which is field `aField` in test class `SomeTest`. We get
```
com.flextrade.jfixture.exceptions.ObjectCreationException: Unable to create an instance of TypeA[] SomeTest.aField because it contains a circular reference.
		TypeA[] SomeTest.aField --> 
		[LTypeA; --> 
		TypeA --> 
		TypeA
```

But `TypeA` doesn't contain any fields of type `TypeA`, or any setters that require a `TypeA` so there shouldn't be a recursion error. What seems to be happening is that one of its setters requires a type that has multiple constructors, one of which throws a `NumberFormatException` when invoked by `JFixture` because the provided string can't be parsed as a number:
```
com.flextrade.jfixture.exceptions.ObjectCreationException: Unable to invoke constructor public Quantity(java.lang.String)
java.lang.reflect.InvocationTargetException
java.lang.NumberFormatException
```

The other constructor takes a `Long` and succeeds, but the exception is propagating past the `RecursionGuard`, which isn't popping the failed request for `Quantity` off the stack. This means it always thinks it's one level deeper in the request stack than it actually is, meaning when it finally goes to request the next `TypeA` for the array it hasn't popped the original `TypeA` request off the stack and it thinks there's a circular reference.

The following is a simple way to reproduce the issue:
```
class TypeWithThrowingConstructor {
    public TypeWithThrowingConstructor() {
        throw new RuntimeException();
    }
    public TypeWithThrowingConstructor(String string) {
    }
}

class TypeWithFieldWithThrowingConstructor {
    public TypeWithThrowingConstructor fieldWithThrowingConstructor;
}

JFixture fixture = new JFixture();
fixture.create(TypeWithFieldWithThrowingConstructor[].class);
```

The solution we employ here is to make sure that `RecursionGuard` always pops requests off the stack, even if they throw an exception.