### PR TITLE
Add support for inheritance with generic types - fixes issue #36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk7
+- oraclejdk8
 branches:
   only:
   - master

--- a/jfixture/src/main/java/com/flextrade/jfixture/customisation/CustomBuilder.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/customisation/CustomBuilder.java
@@ -43,7 +43,7 @@ class CustomBuilder<T> implements SpecimenBuilder {
         Type type = (Type)request;
 
         // should be isAssignableFrom ?
-        if (!this.specimenType.equals(type) && !this.specimenType.getRawType().equals(type)) {
+        if (!this.specimenType.equals(type)) {
             return new NoSpecimen();
         }
 

--- a/jfixture/src/main/java/com/flextrade/jfixture/customisation/CustomBuilder.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/customisation/CustomBuilder.java
@@ -1,13 +1,13 @@
 package com.flextrade.jfixture.customisation;
 
+import java.lang.reflect.Type;
+
 import com.flextrade.jfixture.NoSpecimen;
 import com.flextrade.jfixture.SpecimenBuilder;
 import com.flextrade.jfixture.SpecimenContext;
 import com.flextrade.jfixture.SpecimenSupplier;
 import com.flextrade.jfixture.requests.SeededRequest;
 import com.flextrade.jfixture.utility.SpecimenType;
-
-import java.lang.reflect.Type;
 
 class CustomBuilder<T> implements SpecimenBuilder {
 
@@ -43,7 +43,7 @@ class CustomBuilder<T> implements SpecimenBuilder {
         Type type = (Type)request;
 
         // should be isAssignableFrom ?
-        if (!this.specimenType.equals(type)) {
+        if (!this.specimenType.equals(type) && !this.specimenType.getRawType().equals(type)) {
             return new NoSpecimen();
         }
 

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericType.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericType.java
@@ -1,5 +1,7 @@
 package com.flextrade.jfixture.utility;
 
+import java.lang.reflect.Type;
+
 public class GenericType {
 
     private final SpecimenType type;
@@ -34,4 +36,30 @@ public class GenericType {
         result = 31 * result + name.hashCode();
         return result;
     }
+
+
+    public interface GenericTypeCreator {
+        GenericType createGenericType(Type type, String name);
+    }
+
+    public static class GenericTypeCreatorImpl implements GenericTypeCreator {
+        @Override
+        public GenericType createGenericType(Type type, String name) {
+            return new GenericType(SpecimenType.of(type), name);
+        }
+    }
+
+    public static class GenericTypeCreatorWithGenericContextImpl implements GenericTypeCreator {
+        private final SpecimenType contextType;
+
+        public GenericTypeCreatorWithGenericContextImpl(SpecimenType contextType) {
+            this.contextType = contextType;
+        }
+
+        @Override
+        public GenericType createGenericType(Type type, String name) {
+            return new GenericType(SpecimenType.withGenericContext(type, contextType), name);
+        }
+    }
+
 }

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericTypeCollection.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericTypeCollection.java
@@ -43,6 +43,29 @@ public class GenericTypeCollection {
         return length;
     }
 
+    /**
+     *  Combines the generic type mappings of this GenericTypeCollection with the generic type mappings of the {@code other} GenericTypeCollection.
+     *  <p>
+     *  <b>Use case:</b> when a non generic Class {@code Foo} extends a generic type {@code Bar<T>}, example:
+     *  <p>
+     *  <code>Class Foo extends Bar&lt;String&gt;</code>
+     *  <p>
+     *  The generic type mappings for Foo (none in this example) can then be combined with the generic type mappings for {@code Bar<String>}
+     *  <p>
+     *  If {@code other} contains an existing mapping in {@code this} then that mapping will be replaced (i.e. the mapping from {@code other} will be used).
+     *
+     * @param other the other GenericTypeCollection to combine with
+     * @return a new GenericTypeCollection representing a union of {@code this} and {@code other}
+     */
+    public GenericTypeCollection combineWith(GenericTypeCollection other) {
+        int firstLen = this.underlying.length;
+        int secondLen = other.underlying.length;
+        GenericType[] combined = new GenericType[this.underlying.length + other.underlying.length];
+        System.arraycopy(this.underlying, 0, combined, 0, firstLen);
+        System.arraycopy(other.underlying, 0, combined, firstLen, secondLen);
+        return new GenericTypeCollection(combined);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -64,5 +87,10 @@ public class GenericTypeCollection {
         result = 31 * result + Arrays.hashCode(underlying);
         result = 31 * result + length;
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return nameTypeMap.toString();
     }
 }

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericTypeCollection.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/GenericTypeCollection.java
@@ -58,11 +58,11 @@ public class GenericTypeCollection {
      * @return a new GenericTypeCollection representing a union of {@code this} and {@code other}
      */
     public GenericTypeCollection combineWith(GenericTypeCollection other) {
-        int firstLen = this.underlying.length;
-        int secondLen = other.underlying.length;
-        GenericType[] combined = new GenericType[this.underlying.length + other.underlying.length];
-        System.arraycopy(this.underlying, 0, combined, 0, firstLen);
-        System.arraycopy(other.underlying, 0, combined, firstLen, secondLen);
+        int firstLength = this.underlying.length;
+        int secondLength = other.underlying.length;
+        GenericType[] combined = new GenericType[firstLength + secondLength];
+        System.arraycopy(this.underlying, 0, combined, 0, firstLength);
+        System.arraycopy(other.underlying, 0, combined, firstLength, secondLength);
         return new GenericTypeCollection(combined);
     }
 

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/SpecimenType.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/SpecimenType.java
@@ -1,7 +1,5 @@
 package com.flextrade.jfixture.utility;
 
-import sun.reflect.generics.reflectiveObjects.TypeVariableImpl;
-
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -86,7 +84,7 @@ public abstract class SpecimenType<T> implements Type {
         if (originalType instanceof TypeVariable) { // e.g. <T>
             SpecimenType type = contextualType.getGenericTypeArguments().getType(originalType.toString());
             if (type == null) {
-                return SpecimenType.of(TypeVariableImpl.class);
+                return SpecimenType.of(TypeVariable.class);
             }
             return type;
         }
@@ -156,7 +154,7 @@ public abstract class SpecimenType<T> implements Type {
         for (int i = 0; i < genericArguments.length; i++) {
             Type type = genericArguments[i];
             GenericType genericType = genericTypeCreator.createGenericType(type, typeParameters[i].getName());
-            if (!(genericType.getType().getRawType().equals(TypeVariableImpl.class))) { // ignore type parameters which haven't been substituted e.g. T, S, U etc
+            if (!(TypeVariable.class.isAssignableFrom(genericType.getType().getRawType()))) { // ignore type parameters which haven't been substituted e.g. T, S, U etc
                 genericTypes.add(genericType);
             }
         }

--- a/jfixture/src/test/java/component/generics/TestGenericMethods.java
+++ b/jfixture/src/test/java/component/generics/TestGenericMethods.java
@@ -1,19 +1,17 @@
 package component.generics;
 
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.assertNotNull;
-
+import com.flextrade.jfixture.JFixture;
+import com.flextrade.jfixture.utility.SpecimenType;
 import junit.framework.TestCase;
-import testtypes.generic.TypeWithGenericMethod;
-
 import org.junit.Before;
 import org.junit.Test;
+import testtypes.generic.TypeWithGenericMethod;
 
 import java.math.BigDecimal;
 import java.util.Map;
 
-import com.flextrade.jfixture.JFixture;
-import com.flextrade.jfixture.utility.SpecimenType;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
 
 public class TestGenericMethods {
 

--- a/jfixture/src/test/java/component/generics/TestGenericMethods.java
+++ b/jfixture/src/test/java/component/generics/TestGenericMethods.java
@@ -1,17 +1,19 @@
 package component.generics;
 
-import com.flextrade.jfixture.JFixture;
-import com.flextrade.jfixture.utility.SpecimenType;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
+
 import junit.framework.TestCase;
+import testtypes.generic.TypeWithGenericMethod;
+
 import org.junit.Before;
 import org.junit.Test;
-import testtypes.generic.TypeWithGenericMethod;
 
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.assertNotNull;
+import com.flextrade.jfixture.JFixture;
+import com.flextrade.jfixture.utility.SpecimenType;
 
 public class TestGenericMethods {
 

--- a/jfixture/src/test/java/component/generics/TestInheritanceWithGenerics.java
+++ b/jfixture/src/test/java/component/generics/TestInheritanceWithGenerics.java
@@ -1,0 +1,73 @@
+package component.generics;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.flextrade.jfixture.JFixture;
+import com.flextrade.jfixture.utility.SpecimenType;
+
+public class TestInheritanceWithGenerics {
+
+  @Test
+  public void non_generic_class_inheriting_a_generic_class_should_fixture_the_generic_types_correctly() {
+    JFixture fixture = new JFixture();
+    ClassInheritingGenericClass newType = fixture.create(ClassInheritingGenericClass.class);
+    assertNotNull(newType.getField());
+    assertThat(newType.getField(), instanceOf(String.class));
+  }
+
+  @Test
+  public void non_generic_class_inheriting_a_generic_class_further_down_the_inheritance_chain_should_fixture_correctly() {
+    JFixture fixture = new JFixture();
+    NestedClassInheritingGenericClass newType = fixture.create(NestedClassInheritingGenericClass.class);
+    assertNotNull(newType.getField());
+    assertThat(newType.getField(), instanceOf(String.class));
+  }
+
+  @Test
+  public void generic_class_inheriting_another_generic_class_should_fixture_correctly() {
+    JFixture fixture = new JFixture();
+    GenericClassExtendingGenericClass<Integer> newType = fixture.create(new SpecimenType<GenericClassExtendingGenericClass<Integer>>(){});
+    assertNotNull(newType.getField());
+    assertThat(newType.getField(), instanceOf(Integer.class));
+    assertNotNull(newType.getOtherField());
+    assertThat(newType.getOtherField(), instanceOf(Integer.class));
+  }
+
+  @Test
+  public void generic_class_inheriting_non_generic_class_inheriting_generic_class_should_fixture_correctly() {
+    JFixture fixture = new JFixture();
+    GenericClassExtendingClassInheritingGenericClass<Integer> newType = fixture.create(new SpecimenType<GenericClassExtendingClassInheritingGenericClass<Integer>>(){});
+    assertNotNull(newType.getField());
+    assertThat(newType.getField(), instanceOf(String.class));
+    assertNotNull(newType.getOtherField());
+    assertThat(newType.getOtherField(), instanceOf(Integer.class));
+  }
+
+
+  public class GenericClass<T> {
+    protected T field;
+    public T getField() { return this.field; }
+    public void setField(T field) { this.field = field; }
+  }
+
+  public class ClassInheritingGenericClass extends GenericClass<String> {}
+
+  public class NestedClassInheritingGenericClass extends ClassInheritingGenericClass {}
+
+  public class GenericClassExtendingGenericClass<S> extends GenericClass<S> {
+    private S otherField;
+    public S getOtherField() { return otherField; }
+    public void setOtherField(S otherField) { this.otherField = otherField; }
+  }
+
+  public class GenericClassExtendingClassInheritingGenericClass<S> extends ClassInheritingGenericClass {
+    private S otherField;
+    public S getOtherField() { return otherField; }
+    public void setOtherField(S otherField) { this.otherField = otherField; }
+  }
+
+}


### PR DESCRIPTION
*Note there are more complex scenarios that aren't covered by this fix - for example if multiple generic types in an inheritance hierarchy use the same Type variable then it this won't work.


There are some comments in the code which explain the reason for certain things - I can get rid of these but for now they might give reviewers a bit more context.

I feel like this is a bit of a naive solution and only really covers a few basic cases (the ones in the unit test essentially), in order to properly cover generic type inheritance we might need to think about how and when SpecimenType should be used.

All tests are passing.