### PR TITLE
Update version to latest SNAPSHOTs

### DIFF
--- a/jfixture-jodatime/pom.xml
+++ b/jfixture-jodatime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.flextrade.jfixture</groupId>
         <artifactId>jfixture-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.7.3-SNAPSHOT</version>
     </parent>
     <artifactId>jfixture-jodatime</artifactId>
     <name>JFixture Joda Time</name>

--- a/jfixture-mockito/pom.xml
+++ b/jfixture-mockito/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.flextrade.jfixture</groupId>
         <artifactId>jfixture-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.7.3-SNAPSHOT</version>
     </parent>
     <artifactId>jfixture-mockito</artifactId>
     <name>JFixture Mockito</name>

--- a/jfixture/pom.xml
+++ b/jfixture/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.flextrade.jfixture</groupId>
         <artifactId>jfixture-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.7.3-SNAPSHOT</version>
     </parent>
     <artifactId>jfixture</artifactId>
     <name>jfixture</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jfixture-parent</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.7.3-SNAPSHOT</version>
     <groupId>com.flextrade.jfixture</groupId>
     <name>JFixture Parent</name>
     <description>JFixture is an open source library based on the popular .NET library, AutoFixture</description>


### PR DESCRIPTION
Local development is difficult without using valid SNAPSHOT
versions as this will pollute the local maven repository