### PR TITLE
Resolve sort order between ambiguous constructor and factory methods

### DIFF
--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/IntegerPolyfill.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/IntegerPolyfill.java
@@ -1,0 +1,10 @@
+package com.flextrade.jfixture.utility;
+
+public class IntegerPolyfill {
+    /**
+     * @see Integer#compare(int, int) Integer.compare since Java 7
+     */
+    public static int compare(int x, int y) {
+        return (x < y) ? -1 : ((x == y) ? 0 : 1);
+    }
+}

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
@@ -1,5 +1,7 @@
 package com.flextrade.jfixture.utility.comparators;
 
+import com.flextrade.jfixture.utility.IntegerPolyfill;
+
 import java.lang.reflect.Constructor;
 import java.util.Comparator;
 
@@ -15,17 +17,10 @@ public class ConstructorParameterCountComparator implements Comparator<Construct
         int ctor1ParameterCount = ctor1.getGenericParameterTypes().length;
         int ctor2ParameterCount = ctor2.getGenericParameterTypes().length;
 
-        int result = compare(ctor1ParameterCount, ctor2ParameterCount);
+        int result = IntegerPolyfill.compare(ctor1ParameterCount, ctor2ParameterCount);
         if (result == 0) {
             return ctor1.toString().compareTo(ctor2.toString());
         }
         return result;
-    }
-
-    /**
-     * @see Integer#compare(int, int) Integer.compare since Java 7
-     */
-    public static int compare(int x, int y) {
-        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 }

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
@@ -5,11 +5,9 @@ import com.flextrade.jfixture.utility.IntegerPolyfill;
 import java.lang.reflect.Constructor;
 import java.util.Comparator;
 
-/**
- * Compare by method parameter count, but if they're equal compare by the actual parameter types.
- * This is necessary as {@link Class#getConstructors()} has no guarantees on order,
- * and for reproducible tests the objects must be constructed in the same way every time a test is run.
- */
+// Duplicate code: ideally this would be compare(Executable, Executable),
+// but that base class was introduced in Java 8, and the current build is Java 6.
+@SuppressWarnings("Duplicates")
 public class ConstructorParameterCountComparator implements Comparator<Constructor<?>> {
 
     @Override
@@ -19,6 +17,9 @@ public class ConstructorParameterCountComparator implements Comparator<Construct
 
         int result = IntegerPolyfill.compare(ctor1ParameterCount, ctor2ParameterCount);
         if (result == 0) {
+            // It is necessary to compare the signature as a disambiguation after the param count comparison,
+            // because Class.getConstructors() has no guarantees on order
+            // and using this comparator in a stable sort could yield different results in different runs.
             return ctor1.toString().compareTo(ctor2.toString());
         }
         return result;

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/ConstructorParameterCountComparator.java
@@ -3,13 +3,29 @@ package com.flextrade.jfixture.utility.comparators;
 import java.lang.reflect.Constructor;
 import java.util.Comparator;
 
+/**
+ * Compare by method parameter count, but if they're equal compare by the actual parameter types.
+ * This is necessary as {@link Class#getConstructors()} has no guarantees on order,
+ * and for reproducible tests the objects must be constructed in the same way every time a test is run.
+ */
 public class ConstructorParameterCountComparator implements Comparator<Constructor<?>> {
 
     @Override
-    public int compare(Constructor ctor1, Constructor ctor2) {
-        Integer ctor1Parameters = ctor1.getGenericParameterTypes().length;
-        Integer ctor2Parameters = ctor2.getGenericParameterTypes().length;
+    public int compare(Constructor<?> ctor1, Constructor<?> ctor2) {
+        int ctor1ParameterCount = ctor1.getGenericParameterTypes().length;
+        int ctor2ParameterCount = ctor2.getGenericParameterTypes().length;
 
-        return ctor1Parameters.compareTo(ctor2Parameters);
+        int result = compare(ctor1ParameterCount, ctor2ParameterCount);
+        if (result == 0) {
+            return ctor1.toString().compareTo(ctor2.toString());
+        }
+        return result;
+    }
+
+    /**
+     * @see Integer#compare(int, int) Integer.compare since Java 7
+     */
+    public static int compare(int x, int y) {
+        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 }

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
@@ -1,5 +1,7 @@
 package com.flextrade.jfixture.utility.comparators;
 
+import com.flextrade.jfixture.utility.IntegerPolyfill;
+
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
@@ -15,17 +17,10 @@ public class MethodParameterCountComparator implements Comparator<Method> {
         int method1ParameterCount = method1.getGenericParameterTypes().length;
         int method2ParameterCount = method2.getGenericParameterTypes().length;
 
-        int result = compare(method1ParameterCount, method2ParameterCount);
+        int result = IntegerPolyfill.compare(method1ParameterCount, method2ParameterCount);
         if (result == 0) {
             return method1.toString().compareTo(method2.toString());
         }
         return result;
-    }
-
-    /**
-     * @see Integer#compare(int, int) Integer.compare since Java 7
-     */
-    public static int compare(int x, int y) {
-        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 }

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
@@ -5,11 +5,9 @@ import com.flextrade.jfixture.utility.IntegerPolyfill;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
-/**
- * Compare by method parameter count, but if they're equal compare by the actual parameter types.
- * This is necessary as {@link Class#getMethods()} has no guarantees on order,
- * and for reproducible tests the objects must be constructed in the same way every time a test is run.
- */
+// Duplicate code: ideally this would be compare(Executable, Executable),
+// but that base class was introduced in Java 8, and the current build is Java 6.
+@SuppressWarnings("Duplicates")
 public class MethodParameterCountComparator implements Comparator<Method> {
 
     @Override
@@ -19,6 +17,9 @@ public class MethodParameterCountComparator implements Comparator<Method> {
 
         int result = IntegerPolyfill.compare(method1ParameterCount, method2ParameterCount);
         if (result == 0) {
+            // It is necessary to compare the signature as a disambiguation after the param count comparison,
+            // because Class.getMethods() has no guarantees on order
+            // and using this comparator in a stable sort could yield different results in different runs.
             return method1.toString().compareTo(method2.toString());
         }
         return result;

--- a/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
+++ b/jfixture/src/main/java/com/flextrade/jfixture/utility/comparators/MethodParameterCountComparator.java
@@ -3,13 +3,29 @@ package com.flextrade.jfixture.utility.comparators;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
+/**
+ * Compare by method parameter count, but if they're equal compare by the actual parameter types.
+ * This is necessary as {@link Class#getMethods()} has no guarantees on order,
+ * and for reproducible tests the objects must be constructed in the same way every time a test is run.
+ */
 public class MethodParameterCountComparator implements Comparator<Method> {
 
     @Override
     public int compare(Method method1, Method method2) {
-        Integer method1Parameters = method1.getGenericParameterTypes().length;
-        Integer method2Parameters = method2.getGenericParameterTypes().length;
+        int method1ParameterCount = method1.getGenericParameterTypes().length;
+        int method2ParameterCount = method2.getGenericParameterTypes().length;
 
-        return method1Parameters.compareTo(method2Parameters);
+        int result = compare(method1ParameterCount, method2ParameterCount);
+        if (result == 0) {
+            return method1.toString().compareTo(method2.toString());
+        }
+        return result;
+    }
+
+    /**
+     * @see Integer#compare(int, int) Integer.compare since Java 7
+     */
+    public static int compare(int x, int y) {
+        return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
 }

--- a/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultConstructorQuery.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultConstructorQuery.java
@@ -5,7 +5,7 @@ import com.flextrade.jfixture.utility.comparators.InverseComparator;
 import org.junit.Before;
 import org.junit.Test;
 import testtypes.constructors.TwoConstructorType;
-import testtypes.constructors.TypeWithAmbiguousConstructors;
+import testtypes.constructors.TypeWithMultipleConstructorsHavingSameParameterCount;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -59,15 +59,16 @@ public class TestDefaultConstructorQuery {
     }
 
     @Test
-    public void sort_by_signature_when_constructors_ambiguous() throws NoSuchMethodException {
+    public void sort_by_signature_when_constructors_have_same_number_of_parameters() throws NoSuchMethodException {
         this.query = new DefaultConstructorQuery(new ConstructorParameterCountComparator());
 
-        List<Constructor<?>> constructors = this.query.getConstructorsForClass(TypeWithAmbiguousConstructors.class);
+        Class<?> targetClass = TypeWithMultipleConstructorsHavingSameParameterCount.class;
+        List<Constructor<?>> constructors = this.query.getConstructorsForClass(targetClass);
 
         assertEquals(4, constructors.size());
-        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(String.class, String.class), constructors.get(0));
-        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class), constructors.get(1));
-        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class), constructors.get(2));
-        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(List.class, List.class), constructors.get(3));
+        assertEquals(targetClass.getConstructor(String.class, String.class), constructors.get(0));
+        assertEquals(targetClass.getConstructor(String.class, List.class), constructors.get(1));
+        assertEquals(targetClass.getConstructor(List.class, String.class), constructors.get(2));
+        assertEquals(targetClass.getConstructor(List.class, List.class), constructors.get(3));
     }
 }

--- a/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultConstructorQuery.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultConstructorQuery.java
@@ -5,6 +5,7 @@ import com.flextrade.jfixture.utility.comparators.InverseComparator;
 import org.junit.Before;
 import org.junit.Test;
 import testtypes.constructors.TwoConstructorType;
+import testtypes.constructors.TypeWithAmbiguousConstructors;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -19,13 +20,13 @@ public class TestDefaultConstructorQuery {
     private Constructor<?> expectedConstructorTwoParameters;
 
     @Before
-    public void initialise() throws Exception {
+    public void initialise() throws NoSuchMethodException {
         expectedConstructorOneParameter = TwoConstructorType.class.getConstructor(String.class);
         expectedConstructorTwoParameters = TwoConstructorType.class.getConstructor(String.class, String.class);
     }
 
     @Test
-    public void returns_all_constructors_for_a_given_class() throws NoSuchMethodException {
+    public void returns_all_constructors_for_a_given_class() {
         this.query = new DefaultConstructorQuery();
 
         List<Constructor<?>> constructors = this.query.getConstructorsForClass(TwoConstructorType.class);
@@ -41,6 +42,7 @@ public class TestDefaultConstructorQuery {
 
         List<Constructor<?>> constructors = this.query.getConstructorsForClass(TwoConstructorType.class);
 
+        assertEquals(2, constructors.size());
         assertEquals(expectedConstructorOneParameter, constructors.get(0));
         assertEquals(expectedConstructorTwoParameters, constructors.get(1));
     }
@@ -51,7 +53,21 @@ public class TestDefaultConstructorQuery {
 
         List<Constructor<?>> constructors = this.query.getConstructorsForClass(TwoConstructorType.class);
 
+        assertEquals(2, constructors.size());
         assertEquals(expectedConstructorTwoParameters, constructors.get(0));
         assertEquals(expectedConstructorOneParameter, constructors.get(1));
+    }
+
+    @Test
+    public void sort_by_signature_when_constructors_ambiguous() throws NoSuchMethodException {
+        this.query = new DefaultConstructorQuery(new ConstructorParameterCountComparator());
+
+        List<Constructor<?>> constructors = this.query.getConstructorsForClass(TypeWithAmbiguousConstructors.class);
+
+        assertEquals(4, constructors.size());
+        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(String.class, String.class), constructors.get(0));
+        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class), constructors.get(1));
+        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class), constructors.get(2));
+        assertEquals(TypeWithAmbiguousConstructors.class.getConstructor(List.class, List.class), constructors.get(3));
     }
 }

--- a/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultFactoryMethodQuery.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/TestDefaultFactoryMethodQuery.java
@@ -21,23 +21,26 @@ public class TestDefaultFactoryMethodQuery {
     private DefaultFactoryMethodQuery query;
     private Method expectedMethodOneParameter;
     private Method expectedMethodTwoParameters;
+    private Method expectedMethodTwoParametersReverse;
 
     @Before
-    public void initialise() throws Exception {
+    public void initialise() throws NoSuchMethodException {
         expectedMethodOneParameter = TypeWithFactoryMethod.class.getMethod("create", String.class);
         expectedMethodTwoParameters = TypeWithFactoryMethod.class.getMethod("create", String.class, int.class);
+        expectedMethodTwoParametersReverse = TypeWithFactoryMethod.class.getMethod("create", int.class, String.class);
     }
 
     @Test
-    public void returns_all_factory_methods_for_a_given_class() throws NoSuchMethodException {
+    public void returns_all_factory_methods_for_a_given_class() {
         // Factory methods are public, static methods with return type assignable to declared type
         this.query = new DefaultFactoryMethodQuery();
 
         List<Method> factoryMethods = this.query.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class));
 
-        assertEquals(2, factoryMethods.size());
+        assertEquals(3, factoryMethods.size());
         assertTrue(factoryMethods.contains(expectedMethodOneParameter));
         assertTrue(factoryMethods.contains(expectedMethodTwoParameters));
+        assertTrue(factoryMethods.contains(expectedMethodTwoParametersReverse));
     }
 
     @Test
@@ -47,7 +50,8 @@ public class TestDefaultFactoryMethodQuery {
         List<Method> factoryMethods = this.query.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class));
 
         assertEquals(expectedMethodOneParameter, factoryMethods.get(0));
-        assertEquals(expectedMethodTwoParameters, factoryMethods.get(1));
+        assertEquals(expectedMethodTwoParametersReverse, factoryMethods.get(1));
+        assertEquals(expectedMethodTwoParameters, factoryMethods.get(2));
     }
 
     @Test
@@ -57,7 +61,8 @@ public class TestDefaultFactoryMethodQuery {
         List<Method> factoryMethods = this.query.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class));
 
         assertEquals(expectedMethodTwoParameters, factoryMethods.get(0));
-        assertEquals(expectedMethodOneParameter, factoryMethods.get(1));
+        assertEquals(expectedMethodTwoParametersReverse, factoryMethods.get(1));
+        assertEquals(expectedMethodOneParameter, factoryMethods.get(2));
     }
 
     @Test

--- a/jfixture/src/test/java/com/flextrade/jfixture/builders/TestClassToFactoryMethodRelay.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/builders/TestClassToFactoryMethodRelay.java
@@ -13,8 +13,9 @@ import testtypes.constructors.TwoConstructorType;
 import testtypes.factorymethods.TypeWithFactoryMethod;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -39,7 +40,7 @@ public class TestClassToFactoryMethodRelay {
     public void initialise() {
         MockitoAnnotations.initMocks(this);
         when(this.mockSpecification.isSatisfiedBy(any())).thenReturn(true);
-        ArrayList<Method> methods = new ArrayList<Method>(Arrays.asList(TypeWithFactoryMethod.class.getMethods()));
+        List<Method> methods = Arrays.asList(TypeWithFactoryMethod.class.getMethods());
         when(this.mockFactoryMethodQuery.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class))).thenReturn(methods);
         this.relay = new ClassToFactoryMethodRelay(this.mockFactoryMethodQuery, this.mockSpecification);
     }
@@ -53,7 +54,7 @@ public class TestClassToFactoryMethodRelay {
 
     @Test
     public void if_factory_method_query_returns_empty_create_returns_no_specimen() {
-        when(this.mockFactoryMethodQuery.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class))).thenReturn(new ArrayList<Method>());
+        when(this.mockFactoryMethodQuery.getFactoryMethodsForType(SpecimenType.of(TypeWithFactoryMethod.class))).thenReturn(Collections.<Method>emptyList());
         Object result = this.relay.create(TwoConstructorType.class, mockSpecimenContext);
         assertEquals(new NoSpecimen(), result);
     }

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
@@ -52,7 +52,6 @@ public class TestConstructorParameterCountComparator {
 
         int result = this.comparator.compare(stringString, stringList);
 
-        // String,String <> String,List
         assertTrue(result != 0);
     }
 
@@ -65,7 +64,6 @@ public class TestConstructorParameterCountComparator {
 
         int result = this.comparator.compare(stringList, listString);
 
-        // java.lang.String,... < java.util.List<String>,...
         assertTrue(result < 0);
     }
 
@@ -76,7 +74,6 @@ public class TestConstructorParameterCountComparator {
         Constructor<?> listString = TypeWithMultipleConstructorsHavingSameParameterCount.class
                 .getConstructor(List.class, String.class);
 
-        // java.util.List<String>,... > java.lang.String,...
         int result = this.comparator.compare(listString, stringList);
 
         assertTrue(result > 0);

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
@@ -9,7 +9,12 @@ import testtypes.constructors.TypeWithMultipleConstructorsHavingSameParameterCou
 import java.lang.reflect.Constructor;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestConstructorParameterCountComparator {
 
@@ -28,19 +33,19 @@ public class TestConstructorParameterCountComparator {
     @Test
     public void returns_less_than_0_if_first_constructor_has_fewer_parameters_than_second() {
         int result = this.comparator.compare(few, many);
-        assertTrue(result < 0);
+        assertThat(result, is(lessThan(0)));
     }
 
     @Test
     public void returns_greater_than_0_if_first_constructor_has_more_parameters_than_second() {
         int result = this.comparator.compare(many, few);
-        assertTrue(result > 0);
+        assertThat(result, is(greaterThan(0)));
     }
 
     @Test
     public void returns_0_if_constructors_have_same_number_of_parameters() {
         int result = this.comparator.compare(few, few);
-        assertTrue(result == 0);
+        assertEquals(0, result);
     }
 
     @Test
@@ -52,7 +57,7 @@ public class TestConstructorParameterCountComparator {
 
         int result = this.comparator.compare(stringString, stringList);
 
-        assertTrue(result != 0);
+        assertNotEquals(0, result);
     }
 
     @Test
@@ -64,7 +69,7 @@ public class TestConstructorParameterCountComparator {
 
         int result = this.comparator.compare(stringList, listString);
 
-        assertTrue(result < 0);
+        assertThat(result, is(lessThan(0)));
     }
 
     @Test
@@ -76,6 +81,6 @@ public class TestConstructorParameterCountComparator {
 
         int result = this.comparator.compare(listString, stringList);
 
-        assertTrue(result > 0);
+        assertThat(result, is(greaterThan(0)));
     }
 }

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
@@ -4,7 +4,7 @@ import com.flextrade.jfixture.utility.comparators.ConstructorParameterCountCompa
 import org.junit.Before;
 import org.junit.Test;
 import testtypes.constructors.TwoConstructorType;
-import testtypes.constructors.TypeWithAmbiguousConstructors;
+import testtypes.constructors.TypeWithMultipleConstructorsHavingSameParameterCount;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -45,8 +45,10 @@ public class TestConstructorParameterCountComparator {
 
     @Test
     public void returns_non_0_if_constructors_have_same_number_of_parameters_but_overloaded() throws NoSuchMethodException {
-        Constructor<?> stringString = TypeWithAmbiguousConstructors.class.getConstructor(String.class, String.class);
-        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
+        Constructor<?> stringString = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(String.class, String.class);
+        Constructor<?> stringList = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(String.class, List.class);
 
         int result = this.comparator.compare(stringString, stringList);
 
@@ -56,8 +58,10 @@ public class TestConstructorParameterCountComparator {
 
     @Test
     public void returns_less_than_0_if_constructors_have_same_number_of_parameters_but_lexicographically_different() throws NoSuchMethodException {
-        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
-        Constructor<?> listString = TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class);
+        Constructor<?> stringList = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(String.class, List.class);
+        Constructor<?> listString = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(List.class, String.class);
 
         int result = this.comparator.compare(stringList, listString);
 
@@ -67,8 +71,10 @@ public class TestConstructorParameterCountComparator {
 
     @Test
     public void returns_greater_than_0_if_constructors_have_same_number_of_parameters_but_lexicographically_different() throws NoSuchMethodException {
-        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
-        Constructor<?> listString = TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class);
+        Constructor<?> stringList = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(String.class, List.class);
+        Constructor<?> listString = TypeWithMultipleConstructorsHavingSameParameterCount.class
+                .getConstructor(List.class, String.class);
 
         // java.util.List<String>,... > java.lang.String,...
         int result = this.comparator.compare(listString, stringList);

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestConstructorParameterCountComparator.java
@@ -4,8 +4,10 @@ import com.flextrade.jfixture.utility.comparators.ConstructorParameterCountCompa
 import org.junit.Before;
 import org.junit.Test;
 import testtypes.constructors.TwoConstructorType;
+import testtypes.constructors.TypeWithAmbiguousConstructors;
 
 import java.lang.reflect.Constructor;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -39,5 +41,38 @@ public class TestConstructorParameterCountComparator {
     public void returns_0_if_constructors_have_same_number_of_parameters() {
         int result = this.comparator.compare(few, few);
         assertTrue(result == 0);
+    }
+
+    @Test
+    public void returns_non_0_if_constructors_have_same_number_of_parameters_but_overloaded() throws NoSuchMethodException {
+        Constructor<?> stringString = TypeWithAmbiguousConstructors.class.getConstructor(String.class, String.class);
+        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
+
+        int result = this.comparator.compare(stringString, stringList);
+
+        // String,String <> String,List
+        assertTrue(result != 0);
+    }
+
+    @Test
+    public void returns_less_than_0_if_constructors_have_same_number_of_parameters_but_lexicographically_different() throws NoSuchMethodException {
+        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
+        Constructor<?> listString = TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class);
+
+        int result = this.comparator.compare(stringList, listString);
+
+        // java.lang.String,... < java.util.List<String>,...
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void returns_greater_than_0_if_constructors_have_same_number_of_parameters_but_lexicographically_different() throws NoSuchMethodException {
+        Constructor<?> stringList = TypeWithAmbiguousConstructors.class.getConstructor(String.class, List.class);
+        Constructor<?> listString = TypeWithAmbiguousConstructors.class.getConstructor(List.class, String.class);
+
+        // java.util.List<String>,... > java.lang.String,...
+        int result = this.comparator.compare(listString, stringList);
+
+        assertTrue(result > 0);
     }
 }

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestIntegerPolyfill.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestIntegerPolyfill.java
@@ -1,0 +1,45 @@
+package com.flextrade.jfixture.utility;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+
+public class TestIntegerPolyfill {
+
+    @Test
+    public void negative_integer_less_than_positive() {
+        assertThat(IntegerPolyfill.compare(-273, 42), is(lessThan(0)));
+        assertThat(IntegerPolyfill.compare(42, -273), is(greaterThan(0)));
+    }
+
+    @Test
+    public void smaller_positive_integer_less_than_larger_positive_integer() {
+        assertThat(IntegerPolyfill.compare(3, 5), is(lessThan(0)));
+        assertThat(IntegerPolyfill.compare(5, 3), is(greaterThan(0)));
+    }
+
+    @Test
+    public void smaller_negative_integer_greater_than_larger_negative_integer() {
+        assertThat(IntegerPolyfill.compare(-3, -5), is(greaterThan(0)));
+        assertThat(IntegerPolyfill.compare(-5, -3), is(lessThan(0)));
+    }
+
+    @Test
+    public void integer_equal_to_itself() {
+        assertEquals(0, IntegerPolyfill.compare(0, 0));
+        assertEquals(0, IntegerPolyfill.compare(42, 42));
+        assertEquals(0, IntegerPolyfill.compare(-273, -273));
+    }
+
+    @Test
+    public void integer_edge_cases_work_as_expected() {
+        assertEquals(0, IntegerPolyfill.compare(Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertEquals(0, IntegerPolyfill.compare(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        assertThat(IntegerPolyfill.compare(Integer.MIN_VALUE, Integer.MAX_VALUE), is(lessThan(0)));
+        assertThat(IntegerPolyfill.compare(Integer.MAX_VALUE, Integer.MIN_VALUE), is(greaterThan(0)));
+    }
+}

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
@@ -13,14 +13,19 @@ public class TestMethodParameterCountComparator {
 
     private MethodParameterCountComparator comparator;
     private Method many;
+    private Method manyReverse;
     private Method few;
 
     @Before
     public void initialise() throws NoSuchMethodException {
         this.comparator = new MethodParameterCountComparator();
 
+        // ....create(java.lang.String)
         this.few = TypeWithFactoryMethod.class.getMethod("create", String.class);
+        // ....create(java.lang.String,int)
         this.many = TypeWithFactoryMethod.class.getMethod("create", String.class, int.class);
+        // ....create(int,java.lang.String)
+        this.manyReverse = TypeWithFactoryMethod.class.getMethod("create", int.class, String.class);
     }
 
     @Test
@@ -40,5 +45,22 @@ public class TestMethodParameterCountComparator {
         int result = this.comparator.compare(few, few);
         assertTrue(result == 0);
     }
-}
 
+    @Test
+    public void returns_non_0_if_methods_have_same_number_of_parameters_but_overloaded() {
+        int result = this.comparator.compare(many, manyReverse);
+        assertTrue(result != 0);
+    }
+
+    @Test
+    public void returns_less_than_0_if_methods_have_same_number_of_parameters_but_lexicographically_different() {
+        int result = this.comparator.compare(manyReverse, many);
+        assertTrue(result < 0);
+    }
+
+    @Test
+    public void returns_greater_than_0_if_methods_have_same_number_of_parameters_but_lexicographically_different() {
+        int result = this.comparator.compare(many, manyReverse);
+        assertTrue(result > 0);
+    }
+}

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
@@ -20,11 +20,8 @@ public class TestMethodParameterCountComparator {
     public void initialise() throws NoSuchMethodException {
         this.comparator = new MethodParameterCountComparator();
 
-        // ....create(java.lang.String)
         this.few = TypeWithFactoryMethod.class.getMethod("create", String.class);
-        // ....create(java.lang.String,int)
         this.many = TypeWithFactoryMethod.class.getMethod("create", String.class, int.class);
-        // ....create(int,java.lang.String)
         this.manyReverse = TypeWithFactoryMethod.class.getMethod("create", int.class, String.class);
     }
 

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestMethodParameterCountComparator.java
@@ -7,7 +7,12 @@ import testtypes.factorymethods.TypeWithFactoryMethod;
 
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TestMethodParameterCountComparator {
 
@@ -28,36 +33,36 @@ public class TestMethodParameterCountComparator {
     @Test
     public void returns_less_than_0_if_first_method_has_fewer_parameters_than_second() {
         int result = this.comparator.compare(few, many);
-        assertTrue(result < 0);
+        assertThat(result, is(lessThan(0)));
     }
 
     @Test
     public void returns_greater_than_0_if_first_method_has_more_parameters_than_second() {
         int result = this.comparator.compare(many, few);
-        assertTrue(result > 0);
+        assertThat(result, is(greaterThan(0)));
     }
 
     @Test
     public void returns_0_if_methods_have_same_number_of_parameters() {
         int result = this.comparator.compare(few, few);
-        assertTrue(result == 0);
+        assertEquals(0, result);
     }
 
     @Test
     public void returns_non_0_if_methods_have_same_number_of_parameters_but_overloaded() {
         int result = this.comparator.compare(many, manyReverse);
-        assertTrue(result != 0);
+        assertNotEquals(0, result);
     }
 
     @Test
     public void returns_less_than_0_if_methods_have_same_number_of_parameters_but_lexicographically_different() {
         int result = this.comparator.compare(manyReverse, many);
-        assertTrue(result < 0);
+        assertThat(result, is(lessThan(0)));
     }
 
     @Test
     public void returns_greater_than_0_if_methods_have_same_number_of_parameters_but_lexicographically_different() {
         int result = this.comparator.compare(many, manyReverse);
-        assertTrue(result > 0);
+        assertThat(result, is(greaterThan(0)));
     }
 }

--- a/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
@@ -5,7 +5,7 @@ import com.flextrade.jfixture.customisation.GreedyConstructorCustomisation;
 import org.junit.Test;
 import testtypes.constructors.ThreeConstructorType;
 import testtypes.constructors.TwoConstructorType;
-import testtypes.constructors.TypeWithAmbiguousConstructors;
+import testtypes.constructors.TypeWithMultipleConstructorsHavingSameParameterCount;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,9 +37,10 @@ public class TestGreedyConstructorCustomisation {
     @Test
     public void creates_type_using_constructor_with_most_parameters_using_the_same_one_every_time() {
         JFixture fixture = new JFixture();
-        fixture.customise(new GreedyConstructorCustomisation(TypeWithAmbiguousConstructors.class));
+        fixture.customise(new GreedyConstructorCustomisation(TypeWithMultipleConstructorsHavingSameParameterCount.class));
 
-        TypeWithAmbiguousConstructors type = fixture.create(TypeWithAmbiguousConstructors.class);
+        TypeWithMultipleConstructorsHavingSameParameterCount type =
+                fixture.create(TypeWithMultipleConstructorsHavingSameParameterCount.class);
 
         // same parameter-count ctors will be sorted by signature,
         // and (java.util.List, java.util.List) will win

--- a/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
@@ -5,7 +5,9 @@ import com.flextrade.jfixture.customisation.GreedyConstructorCustomisation;
 import org.junit.Test;
 import testtypes.constructors.ThreeConstructorType;
 import testtypes.constructors.TwoConstructorType;
+import testtypes.constructors.TypeWithAmbiguousConstructors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -30,5 +32,19 @@ public class TestGreedyConstructorCustomisation {
         assertNotNull(type.getI());
         assertNull(type.getJ());
         assertNull(type.getK());
+    }
+
+    @Test
+    public void creates_type_using_constructor_with_most_parameters_using_the_same_one_every_time() {
+        JFixture fixture = new JFixture();
+        fixture.customise(new GreedyConstructorCustomisation(TypeWithAmbiguousConstructors.class));
+
+        TypeWithAmbiguousConstructors type = fixture.create(TypeWithAmbiguousConstructors.class);
+
+        // same parameter-count ctors will be sorted by signature,
+        // and (java.util.List, java.util.List) will win
+        // over (java.lang.String, java.lang.String) due to reversed comparison
+        assertEquals(3, type.getList1().size());
+        assertEquals(3, type.getList2().size());
     }
 }

--- a/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
@@ -37,6 +37,7 @@ public class TestGreedyConstructorCustomisation {
     @Test
     public void creates_type_using_constructor_with_most_parameters_using_the_same_one_every_time() {
         JFixture fixture = new JFixture();
+        fixture.customise().repeatCount(3);
         fixture.customise(new GreedyConstructorCustomisation(TypeWithMultipleConstructorsHavingSameParameterCount.class));
 
         TypeWithMultipleConstructorsHavingSameParameterCount type =
@@ -44,7 +45,7 @@ public class TestGreedyConstructorCustomisation {
 
         // same parameter-count ctors will be sorted by signature,
         // and (java.util.List, java.util.List) will win
-        // over (java.lang.String, java.lang.String) due to reversed comparison
+        // over (java.lang.String, java.lang.String) due to greedy comparison implemented as inverse comparator
         assertEquals(3, type.getList1().size());
         assertEquals(3, type.getList2().size());
     }

--- a/jfixture/src/test/java/testtypes/constructors/TypeWithAmbiguousConstructors.java
+++ b/jfixture/src/test/java/testtypes/constructors/TypeWithAmbiguousConstructors.java
@@ -1,0 +1,37 @@
+package testtypes.constructors;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This type has multiple constructors, all of them would be picked first by JFixture due to their parameter count.
+ */
+public class TypeWithAmbiguousConstructors {
+    private final List<String> list1;
+    private final List<String> list2;
+
+    public TypeWithAmbiguousConstructors(List<String> list1, List<String> list2) {
+        this.list1 = list1;
+        this.list2 = list2;
+    }
+
+    public TypeWithAmbiguousConstructors(List<String> list1, String item2) {
+        this(list1, Collections.singletonList(item2));
+    }
+
+    public TypeWithAmbiguousConstructors(String item1, List<String> list2) {
+        this(Collections.singletonList(item1), list2);
+    }
+
+    public TypeWithAmbiguousConstructors(String item1, String item2) {
+        this(Collections.singletonList(item1), Collections.singletonList(item2));
+    }
+
+    public List<String> getList1() {
+        return list1;
+    }
+
+    public List<String> getList2() {
+        return list2;
+    }
+}

--- a/jfixture/src/test/java/testtypes/constructors/TypeWithMultipleConstructorsHavingSameParameterCount.java
+++ b/jfixture/src/test/java/testtypes/constructors/TypeWithMultipleConstructorsHavingSameParameterCount.java
@@ -6,24 +6,24 @@ import java.util.List;
 /**
  * This type has multiple constructors, all of them would be picked first by JFixture due to their parameter count.
  */
-public class TypeWithAmbiguousConstructors {
+public class TypeWithMultipleConstructorsHavingSameParameterCount {
     private final List<String> list1;
     private final List<String> list2;
 
-    public TypeWithAmbiguousConstructors(List<String> list1, List<String> list2) {
+    public TypeWithMultipleConstructorsHavingSameParameterCount(List<String> list1, List<String> list2) {
         this.list1 = list1;
         this.list2 = list2;
     }
 
-    public TypeWithAmbiguousConstructors(List<String> list1, String item2) {
+    public TypeWithMultipleConstructorsHavingSameParameterCount(List<String> list1, String item2) {
         this(list1, Collections.singletonList(item2));
     }
 
-    public TypeWithAmbiguousConstructors(String item1, List<String> list2) {
+    public TypeWithMultipleConstructorsHavingSameParameterCount(String item1, List<String> list2) {
         this(Collections.singletonList(item1), list2);
     }
 
-    public TypeWithAmbiguousConstructors(String item1, String item2) {
+    public TypeWithMultipleConstructorsHavingSameParameterCount(String item1, String item2) {
         this(Collections.singletonList(item1), Collections.singletonList(item2));
     }
 

--- a/jfixture/src/test/java/testtypes/constructors/TypeWithMultipleConstructorsHavingSameParameterCount.java
+++ b/jfixture/src/test/java/testtypes/constructors/TypeWithMultipleConstructorsHavingSameParameterCount.java
@@ -3,9 +3,6 @@ package testtypes.constructors;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * This type has multiple constructors, all of them would be picked first by JFixture due to their parameter count.
- */
 public class TypeWithMultipleConstructorsHavingSameParameterCount {
     private final List<String> list1;
     private final List<String> list2;

--- a/jfixture/src/test/java/testtypes/factorymethods/TypeWithFactoryMethod.java
+++ b/jfixture/src/test/java/testtypes/factorymethods/TypeWithFactoryMethod.java
@@ -18,6 +18,11 @@ public class TypeWithFactoryMethod {
         return new TypeWithFactoryMethod(symbol, size);
     }
 
+    public static TypeWithFactoryMethod create(int size, String symbol) {
+        // different logic (+1) for overload, so it's detectable which one was called
+        return new TypeWithFactoryMethod(symbol, size + 1);
+    }
+
     // Not factory method because it's not static
     public TypeWithFactoryMethod create(String symbol, double size) {
         return new TypeWithFactoryMethod(symbol, (int)size);


### PR DESCRIPTION
We have a type similar to `TypeWithAmbiguousConstructors` and ran into a problem of having flaky tests.
This was due to `Class#getMethods()` and `Class#getConstructors()` having no guarantees on order.

`getMethods` explicitly states:
> The elements in the returned array are not sorted and are not in any particular order.

This means that when JFixture gets those arrays and then sorts them the `sort` will be stable and keep the order in the input array, meaning different runs will pick different methods/ctors depending on JVM internals (class loading, potentially even class file structure, or compilation).

This resulted in a different constructor being called randomly on some tests. This also depended on processor usage (parallel JUnit tests were being run) and manifested more that way. One of the few constructors were not compatible with JFixture and threw an exception, this is why we were able to track down the root case.