### PR TITLE
Migrate away from JUnit 3 deprecated APIs

### DIFF
--- a/jfixture/src/test/java/com/flextrade/jfixture/TestMultipleCount.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/TestMultipleCount.java
@@ -3,7 +3,7 @@ package com.flextrade.jfixture;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestMultipleCount {
 

--- a/jfixture/src/test/java/com/flextrade/jfixture/behaviours/specimentype/TestSpecimenTypeInjector.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/behaviours/specimentype/TestSpecimenTypeInjector.java
@@ -9,8 +9,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
 public class TestSpecimenTypeInjector {

--- a/jfixture/src/test/java/com/flextrade/jfixture/behaviours/specimentype/TestSpecimenTypeInjectorBehaviour.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/behaviours/specimentype/TestSpecimenTypeInjectorBehaviour.java
@@ -3,7 +3,7 @@ package com.flextrade.jfixture.behaviours.specimentype;
 import com.flextrade.jfixture.SpecimenBuilder;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class TestSpecimenTypeInjectorBehaviour {

--- a/jfixture/src/test/java/com/flextrade/jfixture/builders/TestCompositeBuilder.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/builders/TestCompositeBuilder.java
@@ -8,8 +8,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/jfixture/src/test/java/com/flextrade/jfixture/requests/enrichers/TestCompositeRequestEnricher.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/requests/enrichers/TestCompositeRequestEnricher.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static junit.framework.Assert.assertSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/jfixture/src/test/java/com/flextrade/jfixture/utility/TestSpecimenType.java
+++ b/jfixture/src/test/java/com/flextrade/jfixture/utility/TestSpecimenType.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestSpecimenType {
 

--- a/jfixture/src/test/java/component/TestExceptionThrowingConstructor.java
+++ b/jfixture/src/test/java/component/TestExceptionThrowingConstructor.java
@@ -4,7 +4,7 @@ import com.flextrade.jfixture.JFixture;
 import org.junit.Test;
 import testtypes.constructors.TypeWithThrowingConstructor;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class TestExceptionThrowingConstructor {
 

--- a/jfixture/src/test/java/component/TestExceptionThrowingFactoryMethod.java
+++ b/jfixture/src/test/java/component/TestExceptionThrowingFactoryMethod.java
@@ -4,7 +4,7 @@ import com.flextrade.jfixture.JFixture;
 import org.junit.Test;
 import testtypes.factorymethods.TypeWithThrowingFactoryMethod;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class TestExceptionThrowingFactoryMethod {
 

--- a/jfixture/src/test/java/component/TestFactoryMethod.java
+++ b/jfixture/src/test/java/component/TestFactoryMethod.java
@@ -9,7 +9,7 @@ import testtypes.factorymethods.GenericTypeWithCopyFactoryMethod;
 import testtypes.factorymethods.TypeWithCopyFactoryMethod;
 import testtypes.generic.TypeWithGenericFactoryMethod;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class TestFactoryMethod {
@@ -22,7 +22,7 @@ public class TestFactoryMethod {
 
         assertTrue(type instanceof ConcreteType);
     }
-    
+
     @Test
     public void factory_method_invoked_for_generic_types() {
         JFixture fixture = new JFixture();
@@ -33,12 +33,12 @@ public class TestFactoryMethod {
         assertNotNull(type.getValue());
     }
 
-    @Test 
+    @Test
     public void factory_copy_methods_are_not_called() {
         JFixture fixture = new JFixture();
 
         TypeWithCopyFactoryMethod type = fixture.create(TypeWithCopyFactoryMethod.class);
-        
+
         assertNotNull(type);
     }
 

--- a/jfixture/src/test/java/component/TestFixtureCollections.java
+++ b/jfixture/src/test/java/component/TestFixtureCollections.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestFixtureCollections {
 

--- a/jfixture/src/test/java/component/annotations/TestFixtureAnnotationWithHierarchy.java
+++ b/jfixture/src/test/java/component/annotations/TestFixtureAnnotationWithHierarchy.java
@@ -3,7 +3,7 @@ package component.annotations;
 import com.flextrade.jfixture.FixtureAnnotations;
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class TestFixtureAnnotationWithHierarchy extends BaseTestClassWithFixture {
 

--- a/jfixture/src/test/java/component/behaviours/TestInterceptingSpecimen.java
+++ b/jfixture/src/test/java/component/behaviours/TestInterceptingSpecimen.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestInterceptingSpecimen {
 

--- a/jfixture/src/test/java/component/behaviours/TestTransformerSpecimen.java
+++ b/jfixture/src/test/java/component/behaviours/TestTransformerSpecimen.java
@@ -1,7 +1,7 @@
 package component.behaviours;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 

--- a/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestGreedyConstructorCustomisation.java
@@ -6,8 +6,8 @@ import org.junit.Test;
 import testtypes.constructors.ThreeConstructorType;
 import testtypes.constructors.TwoConstructorType;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class TestGreedyConstructorCustomisation {
 

--- a/jfixture/src/test/java/component/customisation/TestInstanceCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestInstanceCustomisation.java
@@ -9,9 +9,9 @@ import testtypes.generic.TypeWithGenericField;
 
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 public class TestInstanceCustomisation {
 

--- a/jfixture/src/test/java/component/customisation/TestInstanceFactoryCustomisation.java
+++ b/jfixture/src/test/java/component/customisation/TestInstanceFactoryCustomisation.java
@@ -9,8 +9,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import testtypes.TypeWithProperties;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/jfixture/src/test/java/component/generics/TestGenericConstructor.java
+++ b/jfixture/src/test/java/component/generics/TestGenericConstructor.java
@@ -6,7 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import testtypes.generic.TypeWithGenericConstructor;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class TestGenericConstructor {
 

--- a/jfixture/src/test/java/component/generics/TestGenericFields.java
+++ b/jfixture/src/test/java/component/generics/TestGenericFields.java
@@ -9,8 +9,8 @@ import testtypes.generic.TypeWithGenericField;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestGenericFields {
 

--- a/jfixture/src/test/java/component/generics/TestGenericMethods.java
+++ b/jfixture/src/test/java/component/generics/TestGenericMethods.java
@@ -2,7 +2,6 @@ package component.generics;
 
 import com.flextrade.jfixture.JFixture;
 import com.flextrade.jfixture.utility.SpecimenType;
-import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import testtypes.generic.TypeWithGenericMethod;
@@ -10,8 +9,8 @@ import testtypes.generic.TypeWithGenericMethod;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestGenericMethods {
 
@@ -66,9 +65,9 @@ public class TestGenericMethods {
     public void populates_fields_with_doubly_nested_generic_type() {
         TypeWithGenericMethod<String, BigDecimal> type = fixture.create(new SpecimenType<TypeWithGenericMethod<String, BigDecimal>>(){});
         assertNotNull(type.getGenericListOfListT());
-        TestCase.assertTrue(type.getGenericListOfListT().size() > 0);
-        TestCase.assertTrue(type.getGenericListOfListT().get(0).size() > 0);
-        TestCase.assertTrue(type.getGenericListOfListT().get(0).get(0) instanceof String);
+        assertTrue(type.getGenericListOfListT().size() > 0);
+        assertTrue(type.getGenericListOfListT().get(0).size() > 0);
+        assertTrue(type.getGenericListOfListT().get(0).get(0) instanceof String);
     }
 
     @Test
@@ -76,9 +75,9 @@ public class TestGenericMethods {
     public void populates_fields_with_doubly_nested_hard_coded_generic_type() {
         TypeWithGenericMethod<String, BigDecimal> type = fixture.create(new SpecimenType<TypeWithGenericMethod<String, BigDecimal>>(){});
         assertNotNull(type.getGenericTypesListOfList());
-        TestCase.assertTrue(type.getGenericTypesListOfList().size() > 0);
-        TestCase.assertTrue(type.getGenericTypesListOfList().get(0).size() > 0);
-        TestCase.assertTrue(type.getGenericTypesListOfList().get(0).get(0) instanceof Double);
+        assertTrue(type.getGenericTypesListOfList().size() > 0);
+        assertTrue(type.getGenericTypesListOfList().get(0).size() > 0);
+        assertTrue(type.getGenericTypesListOfList().get(0).get(0) instanceof Double);
     }
 
     @Test
@@ -86,11 +85,11 @@ public class TestGenericMethods {
     public void populates_fields_with_nested_types_with_multiple_generic_arguments() {
         TypeWithGenericMethod<String, BigDecimal> type = fixture.create(new SpecimenType<TypeWithGenericMethod<String, BigDecimal>>(){});
         assertNotNull(type.getGenericListOfMap());
-        TestCase.assertTrue(type.getGenericListOfMap().size() > 0);
-        TestCase.assertTrue(type.getGenericListOfMap().get(0).size() > 0);
+        assertTrue(type.getGenericListOfMap().size() > 0);
+        assertTrue(type.getGenericListOfMap().get(0).size() > 0);
         Map.Entry outerMapFirstEntry = type.getGenericListOfMap().get(0).entrySet().iterator().next();
-        TestCase.assertTrue(outerMapFirstEntry.getKey() instanceof String);
-        TestCase.assertTrue(outerMapFirstEntry.getValue() instanceof BigDecimal);
+        assertTrue(outerMapFirstEntry.getKey() instanceof String);
+        assertTrue(outerMapFirstEntry.getValue() instanceof BigDecimal);
     }
 
     @Test
@@ -98,11 +97,11 @@ public class TestGenericMethods {
     public void populates_fields_with_nested_types_with_multiple_partially_bounded_generic_arguments() {
         TypeWithGenericMethod<String, BigDecimal> type = fixture.create(new SpecimenType<TypeWithGenericMethod<String, BigDecimal>>() {});
         assertNotNull(type.getGenericPartiallyBound());
-        TestCase.assertTrue(type.getGenericPartiallyBound().size() > 0);
+        assertTrue(type.getGenericPartiallyBound().size() > 0);
         Map.Entry outerMapFirstEntry = type.getGenericPartiallyBound().entrySet().iterator().next();
         Map.Entry innerMapFirstEntry = ((Map<?,?>) outerMapFirstEntry.getValue()).entrySet().iterator().next();
 
-        TestCase.assertTrue(innerMapFirstEntry.getKey() instanceof Integer);
-        TestCase.assertTrue(innerMapFirstEntry.getValue() instanceof BigDecimal);
+        assertTrue(innerMapFirstEntry.getKey() instanceof Integer);
+        assertTrue(innerMapFirstEntry.getValue() instanceof BigDecimal);
     }
 }

--- a/jfixture/src/test/java/component/generics/TestGenerics.java
+++ b/jfixture/src/test/java/component/generics/TestGenerics.java
@@ -8,7 +8,7 @@ import testtypes.generic.TypeWithGenericParameter;
 import testtypes.generic.TypeWithGenericParameterWithConstructor;
 import testtypes.generic.TypeWithTwoGenericParameters;
 
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 
 public class TestGenerics {
 


### PR DESCRIPTION
Just to reduce compilation noise and move towards current standards.