### PR TITLE
SUPPORT FOR JUNIT 5

### DIFF
--- a/jfixture-jodatime/pom.xml
+++ b/jfixture-jodatime/pom.xml
@@ -17,8 +17,8 @@
         <dependency>
             <groupId>com.flextrade.jfixture</groupId>
             <artifactId>jfixture</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
+
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>

--- a/jfixture-jodatime/pom.xml
+++ b/jfixture-jodatime/pom.xml
@@ -25,5 +25,17 @@
 			<version>[2,)</version>
 			<scope>provided</scope>
 		</dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/jfixture-jupiter/pom.xml
+++ b/jfixture-jupiter/pom.xml
@@ -39,4 +39,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jfixture-jupiter/pom.xml
+++ b/jfixture-jupiter/pom.xml
@@ -8,27 +8,34 @@
         <artifactId>jfixture-parent</artifactId>
         <version>2.7.3-SNAPSHOT</version>
     </parent>
-    <artifactId>jfixture-mockito</artifactId>
-    <name>JFixture Mockito</name>
-    <description>A mockito customisation for handling interfaces/abstract classes in JFixture.</description>
-    <url>https://github.com/FlexTradeUKLtd/jfixture</url>
+    <artifactId>jfixture-jupiter</artifactId>
+    <name>JFixture Jupiter</name>
+    <description>A Jupiter extension for JFixture</description>
     <packaging>jar</packaging>
+    <properties>
+        <junit.version>5.4.2</junit.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.flextrade.jfixture</groupId>
             <artifactId>jfixture</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>[1.8,)</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jfixture-jupiter/src/main/java/com/flextrade/jfixture/jupiter/FixtureExtension.java
+++ b/jfixture-jupiter/src/main/java/com/flextrade/jfixture/jupiter/FixtureExtension.java
@@ -1,0 +1,15 @@
+package com.flextrade.jfixture.jupiter;
+
+import com.flextrade.jfixture.FixtureAnnotations;
+import com.flextrade.jfixture.JFixture;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+public class FixtureExtension implements TestInstancePostProcessor {
+    private final JFixture fixture = new JFixture();
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+        FixtureAnnotations.initFixtures(testInstance, fixture);
+    }
+}

--- a/jfixture-jupiter/src/test/java/com/flextrade/jfixture/jupiter/Data.java
+++ b/jfixture-jupiter/src/test/java/com/flextrade/jfixture/jupiter/Data.java
@@ -1,0 +1,13 @@
+package com.flextrade.jfixture.jupiter;
+
+public class Data<T> {
+    private final T value;
+
+    public Data(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/jfixture-jupiter/src/test/java/com/flextrade/jfixture/jupiter/FixtureExtensionTest.java
+++ b/jfixture-jupiter/src/test/java/com/flextrade/jfixture/jupiter/FixtureExtensionTest.java
@@ -1,0 +1,26 @@
+package com.flextrade.jfixture.jupiter;
+
+import com.flextrade.jfixture.annotations.Fixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(FixtureExtension.class)
+class FixtureExtensionTest {
+    @Fixture
+    private Map<Long, Data<String>> map;
+
+    @Test
+    void fixtures_should_be_created_for_maps_with_correct_types() {
+        assertNotNull(map);
+
+        assertTrue(map.size() > 0);
+        assertTrue(map.keySet().iterator().next().getClass().isAssignableFrom(Long.class));
+        assertTrue(map.values().iterator().next().getClass().isAssignableFrom(Data.class));
+        assertTrue(map.values().iterator().next().getValue().getClass().isAssignableFrom(String.class));
+    }
+}

--- a/jfixture-mockito/pom.xml
+++ b/jfixture-mockito/pom.xml
@@ -19,11 +19,18 @@
             <artifactId>jfixture</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>[1.8,)</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jfixture/pom.xml
+++ b/jfixture/pom.xml
@@ -13,4 +13,24 @@
     <description>JFixture is an open source library based on the popular .NET library, AutoFixture</description>
     <url>https://github.com/FlexTradeUKLtd/jfixture</url>
     <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.flextrade.jfixture</groupId>
+                <artifactId>jfixture</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.11</version>
@@ -85,5 +91,6 @@
         <module>jfixture</module>
         <module>jfixture-mockito</module>
         <module>jfixture-jodatime</module>
+        <module>jfixture-jupiter</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,28 +43,31 @@
         <developerConnection>scm:git:git@github.com:FlexTradeUKLtd/jfixture.git</developerConnection>
         <url>http://github.com/FlexTradeUKLtd/jfixture.git</url>
     </scm>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>provided</scope>
-        </dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.8.4</version>
-            <scope>test</scope>
-        </dependency>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>
+                <scope>provided</scope>
+            </dependency>
 
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.8.4</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <distributionManagement>
         <snapshotRepository>
@@ -79,8 +82,8 @@
     </distributionManagement>
 
     <modules>
-    	<module>jfixture</module>
-    	<module>jfixture-mockito</module>
-    	<module>jfixture-jodatime</module>
+        <module>jfixture</module>
+        <module>jfixture-mockito</module>
+        <module>jfixture-jodatime</module>
     </modules>
 </project>


### PR DESCRIPTION
I'VE DONE LITTLE WORK TO GET JFIXTURE WORKING WITH JUNIT5, BUT IT COMES TWO-FOLDS:

1. CLEANED UP DEPENDENCIES SO THAT I CAN USE JUPITER AS A MODULE
2. ADDED `FixtureExtension` THAT JUPITER :heart: 

I'VE NOT ADDED SUPPORT FOR CUSTOMISATIONS AS YET AS I DON'T NEED THEM FOR MY USE CASE AT THE MOMENT. ADDING CUSTOMISATIONS WILL BE EASY AS JUPITER HAS `RegisterExtension` WHICH CAN BE USED TO MODIFY JFIXTURE